### PR TITLE
Change search method return types to SearchResult

### DIFF
--- a/search/algorithms/astar.py
+++ b/search/algorithms/astar.py
@@ -1,5 +1,6 @@
 import heapq
 from search.base import GraphSearch
+from search.models.result import SearchResult
 
 
 class AStar(GraphSearch):
@@ -8,5 +9,5 @@ class AStar(GraphSearch):
     def __init__(self, graph: dict):
         pass
 
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         pass

--- a/search/algorithms/bfs.py
+++ b/search/algorithms/bfs.py
@@ -1,5 +1,6 @@
 from collections import deque
 from search.base import GraphSearch
+from search.models.result import SearchResult
 
 
 class BFS(GraphSearch):
@@ -8,5 +9,5 @@ class BFS(GraphSearch):
     def __init__(self, graph: dict):
         pass
 
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         pass

--- a/search/algorithms/cus1.py
+++ b/search/algorithms/cus1.py
@@ -1,4 +1,5 @@
 from search.base import GraphSearch
+from search.models.result import SearchResult
 
 
 class CUS1(GraphSearch):
@@ -7,5 +8,5 @@ class CUS1(GraphSearch):
     def __init__(self, graph: dict):
         pass
 
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         pass

--- a/search/algorithms/cus2.py
+++ b/search/algorithms/cus2.py
@@ -1,4 +1,5 @@
 from search.base import GraphSearch
+from search.models.result import SearchResult
 
 
 class CUS2(GraphSearch):
@@ -7,5 +8,5 @@ class CUS2(GraphSearch):
     def __init__(self, graph: dict):
         pass
 
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         pass

--- a/search/algorithms/gbfs.py
+++ b/search/algorithms/gbfs.py
@@ -1,5 +1,6 @@
 import heapq
 from search.base import GraphSearch
+from search.models.result import SearchResult
 
 
 class GBFS(GraphSearch):
@@ -8,5 +9,5 @@ class GBFS(GraphSearch):
     def __init__(self, graph: dict):
         pass
 
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         pass

--- a/search/base.py
+++ b/search/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from search.models.result import SearchResult
 
 
 class GraphSearch(ABC):
@@ -14,12 +15,12 @@ class GraphSearch(ABC):
         pass
 
     @abstractmethod
-    def search(self, origin: int, destinations: list[int]) -> dict:
+    def search(self, origin: int, destinations: list[int]) -> SearchResult:
         """
         Perform the search from origin to one of the destination nodes.
 
         :param origin: starting node ID
         :param destinations: list of goal node IDs
-        :return: SearchResult as dict
+        :return: SearchResult
         """
         pass


### PR DESCRIPTION
This pull request updates the search algorithm interface and its implementations to use a unified `SearchResult` type for search results, improving type safety and consistency across the codebase. The changes ensure that all search algorithms now return a `SearchResult` object instead of a plain dictionary. fixed #13 

**Interface and type consistency improvements:**

* Updated the `search` method signature in the abstract base class `GraphSearch` (in `search/base.py`) to return a `SearchResult` instead of a `dict`, and updated the docstring accordingly.
* Changed the `search` method signature in all algorithm classes (`AStar`, `GBFS`, `BFS`, `CUS1`, `CUS2`) to return a `SearchResult` instead of a `dict`. [[1]](diffhunk://#diff-a72b3b010d5f9e69a34973da9e18a2d45e4b1924cf4f1a21ee5d665695326f21L11-R12) [[2]](diffhunk://#diff-7fcf09294b0886b52adf704c1ec48d5685efcfb1fb3efa21c2bc8909065bd6eeL11-R12) [[3]](diffhunk://#diff-48a184ed7e7dcb2e56bcc81826473f6bef36c88f2f39f89199b7895ca8cc1757L11-R12) [[4]](diffhunk://#diff-55a1568474c00b5ca70b47024c46cdc4d460fe355106f36fc4a22e1b724f4f96L10-R11) [[5]](diffhunk://#diff-f66d8d05fc8c4e228df669338dea900f8ff57c58a43369b5cd6a6eaa76d8a13cL10-R11)

**Import updates for new result type:**

* Added imports for `SearchResult` from `search.models.result` in all relevant files to support the new return type. [[1]](diffhunk://#diff-b337a11cbb9d08fff090bd49ef90ed3fedf9a48a4f1a0b87a44fd2f08f064264R2) [[2]](diffhunk://#diff-a72b3b010d5f9e69a34973da9e18a2d45e4b1924cf4f1a21ee5d665695326f21R3) [[3]](diffhunk://#diff-7fcf09294b0886b52adf704c1ec48d5685efcfb1fb3efa21c2bc8909065bd6eeR3) [[4]](diffhunk://#diff-48a184ed7e7dcb2e56bcc81826473f6bef36c88f2f39f89199b7895ca8cc1757R3) [[5]](diffhunk://#diff-55a1568474c00b5ca70b47024c46cdc4d460fe355106f36fc4a22e1b724f4f96R2) [[6]](diffhunk://#diff-f66d8d05fc8c4e228df669338dea900f8ff57c58a43369b5cd6a6eaa76d8a13cR2)