### PR TITLE
Add dfs and bfs test for map 2

### DIFF
--- a/tests/test_map2.py
+++ b/tests/test_map2.py
@@ -1,0 +1,57 @@
+import pytest
+from search.algorithms.dfs import DFS
+from search.algorithms.bfs import BFS
+from search.services.parser import load_map
+
+
+class TestMap2:
+    """Integration tests for Map2 using DFS and BFS."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load Map2 before each test."""
+        origin, destinations, self.graph = load_map("maps/Map2.txt")
+        self.origin = origin
+        self.destinations = destinations
+
+    def test_dfs(self):
+        """Test DFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [11], "expected_path": [1, 2, 4, 6, 7, 8, 9, 10, 11], "expected_cost": 52, "expected_nodes": 11},
+            {"origin": 1, "destinations": [5], "expected_path": [1, 2, 4, 6, 7, 5], "expected_cost": 28, "expected_nodes": 10},
+            {"origin": 3, "destinations": [11], "expected_path": [3, 1, 2, 4, 6, 7, 8, 9, 10, 11], "expected_cost": 58, "expected_nodes": 11},
+            {"origin": 6, "destinations": [9], "expected_path": [6, 1, 2, 4, 8, 7, 9], "expected_cost": 40, "expected_nodes": 10},
+            {"origin": 5, "destinations": [1], "expected_path": [5, 3, 1], "expected_cost": 11, "expected_nodes": 4},
+        ]
+
+        dfs = DFS(self.graph)
+        for tc in test_cases:
+            result = dfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            assert result.destination == tc["expected_path"][-1]
+
+    def test_bfs(self):
+        """Test BFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [11], "expected_path": [1, 2, 4, 10, 11], "expected_cost": 35, "expected_nodes": 11},
+            {"origin": 1, "destinations": [5], "expected_path": [1, 3, 5], "expected_cost": 11, "expected_nodes": 9},
+            {"origin": 3, "destinations": [11], "expected_path": [3, 5, 7, 9, 11], "expected_cost": 22, "expected_nodes": 11},
+            {"origin": 6, "destinations": [9], "expected_path": [6, 7, 9], "expected_cost": 14, "expected_nodes": 11},
+            {"origin": 5, "destinations": [1], "expected_path": [5, 3, 1], "expected_cost": 11, "expected_nodes": 6},
+        ]
+
+        bfs = BFS(self.graph)
+        for tc in test_cases:
+            result = bfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            assert result.destination == tc["expected_path"][-1]


### PR DESCRIPTION
This pull request adds a new integration test suite for `Map2` to ensure the correctness of the DFS and BFS search algorithms over various origin-destination pairs. The tests verify that both algorithms return the expected paths, costs, and node counts for multiple scenarios.

**New integration tests for search algorithms:**

* Added `TestMap2` class in `tests/test_map2.py` to test DFS and BFS algorithms on `Map2` with multiple origin-destination pairs, checking for correct paths, costs, and node counts.

#26 (Only Map 2 finished)