### PR TITLE
Add dfs and bfs test for map 3

### DIFF
--- a/tests/test_map3.py
+++ b/tests/test_map3.py
@@ -1,5 +1,6 @@
 import pytest
 from search.algorithms.dfs import DFS
+from search.algorithms.bfs import BFS
 from search.services.parser import load_map
 
 
@@ -26,6 +27,31 @@ class TestMap3:
         dfs = DFS(self.graph)
         for tc in test_cases:
             result = dfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"] is not None:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_bfs(self):
+        """Test BFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 2, "destinations": [6], "expected_path": [2, 4, 6], "expected_cost": 13, "expected_nodes": 7},
+            {"origin": 1, "destinations": [6], "expected_path": [1, 2, 4, 6], "expected_cost": 19, "expected_nodes": 7},
+            {"origin": 3, "destinations": [6], "expected_path": [3, 2, 4, 6], "expected_cost": 21, "expected_nodes": 7},
+            {"origin": 5, "destinations": [1], "expected_path": [5, 2, 1], "expected_cost": 14, "expected_nodes": 7},
+            {"origin": 4, "destinations": [1], "expected_path": [4, 2, 1], "expected_cost": 13, "expected_nodes": 7},
+        ]
+
+        bfs = BFS(self.graph)
+        for tc in test_cases:
+            result = bfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map3.py
+++ b/tests/test_map3.py
@@ -1,0 +1,39 @@
+import pytest
+from search.algorithms.dfs import DFS
+from search.services.parser import load_map
+
+
+class TestMap3:
+    """Integration tests for Map3 using DFS."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load Map3 before each test."""
+        origin, destinations, self.graph = load_map("maps/Map3.txt")
+        self.origin = origin
+        self.destinations = destinations
+
+    def test_dfs(self):
+        """Test DFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 2, "destinations": [7], "expected_path": None, "expected_cost":0 , "expected_nodes": 7},
+            {"origin": 2, "destinations": [6], "expected_path": [2, 1, 3, 5, 4, 6], "expected_cost": 32, "expected_nodes": 7},
+            {"origin": 1, "destinations": [7], "expected_path": None, "expected_cost": 0, "expected_nodes": 7},
+            {"origin": 3, "destinations": [6], "expected_path": [3, 1, 2, 4, 5, 8, 6], "expected_cost": 48, "expected_nodes": 7},
+            {"origin": 5, "destinations": [1], "expected_path": [5, 2, 1], "expected_cost": 14, "expected_nodes": 6},
+        ]
+
+        dfs = DFS(self.graph)
+        for tc in test_cases:
+            result = dfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"] is not None:
+                assert result.destination == tc["expected_path"][-1]


### PR DESCRIPTION
This pull request adds new integration tests for Map3, specifically targeting the DFS and BFS search algorithms. The tests verify correct pathfinding, path cost, and node expansion counts for various origin-destination pairs on the Map3 graph.

**New integration tests for Map3:**

* Added a `TestMap3` class in `tests/test_map3.py` to provide comprehensive integration tests for DFS and BFS algorithms using the Map3 map.
  * The tests cover multiple origin-destination scenarios, checking for correct path, path cost, and number of nodes created for both DFS and BFS.
  * Uses a pytest fixture to load the Map3 graph before each test, ensuring test isolation and repeatability.
  
  Finish #26 