### PR TITLE
Test/map 5

### DIFF
--- a/tests/test_map5.py
+++ b/tests/test_map5.py
@@ -1,0 +1,76 @@
+import pytest
+from search.algorithms.dfs import DFS
+from search.algorithms.bfs import BFS
+from search.algorithms.astar import AStar
+from search.services.parser import load_map
+
+
+class TestMap5:
+    """Integration tests for Map5 using DFS, BFS, and A*."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load Map5 before each test."""
+        origin, destinations, self.graph = load_map("maps/Map5.txt")
+        self.origin = origin
+        self.destinations = destinations
+
+    def test_dfs(self):
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        dfs = DFS(self.graph)
+        for tc in test_cases:
+            result = dfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_bfs(self):
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        bfs = BFS(self.graph)
+        for tc in test_cases:
+            result = bfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_astar(self):
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        astar = AStar(self.graph)
+        for tc in test_cases:
+            result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]

--- a/tests/test_map5.py
+++ b/tests/test_map5.py
@@ -17,7 +17,7 @@ class TestMap5:
 
     def test_dfs(self):
         test_cases = [
-            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], "expected_cost": 47, "expected_nodes": 15},
         ]
 
         dfs = DFS(self.graph)
@@ -37,7 +37,7 @@ class TestMap5:
 
     def test_bfs(self):
         test_cases = [
-            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15], "expected_cost": 37, "expected_nodes": 15},
         ]
 
         bfs = BFS(self.graph)
@@ -57,7 +57,7 @@ class TestMap5:
 
     def test_astar(self):
         test_cases = [
-            {"origin": 1, "destinations": [15], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15], "expected_cost": 37, "expected_nodes": 15},
         ]
 
         astar = AStar(self.graph)


### PR DESCRIPTION
This pull request adds a new integration test suite for Map5, verifying the correctness of the DFS, BFS, and A* search algorithms on this map. The tests check that each algorithm produces the expected path, cost, and node count when searching from node 1 to node 15.

New integration tests for Map5:

* Added `TestMap5` class to `tests/test_map5.py` to perform integration tests using DFS, BFS, and A* algorithms on Map5, verifying path, cost, and node count for searches from node 1 to 15.

close #49 