### PR TITLE
Test/map 6

### DIFF
--- a/tests/test_map6.py
+++ b/tests/test_map6.py
@@ -17,7 +17,7 @@ class TestMap6:
 
     def test_dfs(self):
         test_cases = [
-            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [12], "expected_path": [1, 2, 3, 4, 11, 12], "expected_cost": 36, "expected_nodes": 12},
         ]
 
         dfs = DFS(self.graph)
@@ -37,7 +37,7 @@ class TestMap6:
 
     def test_bfs(self):
         test_cases = [
-            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [12], "expected_path": [1, 2, 3, 4, 11, 12], "expected_cost": 36, "expected_nodes": 12},
         ]
 
         bfs = BFS(self.graph)
@@ -57,7 +57,7 @@ class TestMap6:
 
     def test_astar(self):
         test_cases = [
-            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [12], "expected_path": [1, 5, 6, 7, 11, 12], "expected_cost": 14, "expected_nodes": 11},
         ]
 
         astar = AStar(self.graph)

--- a/tests/test_map6.py
+++ b/tests/test_map6.py
@@ -1,0 +1,76 @@
+import pytest
+from search.algorithms.dfs import DFS
+from search.algorithms.bfs import BFS
+from search.algorithms.astar import AStar
+from search.services.parser import load_map
+
+
+class TestMap6:
+    """Integration tests for Map6 using DFS, BFS, and A*."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load Map6 before each test."""
+        origin, destinations, self.graph = load_map("maps/Map6.txt")
+        self.origin = origin
+        self.destinations = destinations
+
+    def test_dfs(self):
+        test_cases = [
+            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        dfs = DFS(self.graph)
+        for tc in test_cases:
+            result = dfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_bfs(self):
+        test_cases = [
+            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        bfs = BFS(self.graph)
+        for tc in test_cases:
+            result = bfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_astar(self):
+        test_cases = [
+            {"origin": 1, "destinations": [12], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+        ]
+
+        astar = AStar(self.graph)
+        for tc in test_cases:
+            result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]


### PR DESCRIPTION
This pull request adds new integration tests for Map6 to ensure the correctness of the DFS, BFS, and A* search algorithms. The tests verify that each algorithm finds the expected path, cost, and number of nodes created when searching from node 1 to node 12.

New integration tests for Map6:

* Added `TestMap6` class in `tests/test_map6.py` with integration tests for DFS, BFS, and A* algorithms, verifying expected paths, costs, and node counts for searches from node 1 to node 12.

close #50 