### PR TITLE
Implement test_gbfs from map1 to map7

### DIFF
--- a/tests/test_map1.py
+++ b/tests/test_map1.py
@@ -2,6 +2,7 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
@@ -78,6 +79,28 @@ class TestMap1:
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [5, 7], "expected_path": [1, 6, 5], "expected_cost": 15, "expected_nodes": 5},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map2.py
+++ b/tests/test_map2.py
@@ -1,6 +1,7 @@
 import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
@@ -55,3 +56,25 @@ class TestMap2:
             assert result.path_cost == tc["expected_cost"]
             assert result.nodes_created == tc["expected_nodes"]
             assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [11], "expected_path": [1, 6, 7, 9, 11], "expected_cost": 29, "expected_nodes": 11},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]

--- a/tests/test_map3.py
+++ b/tests/test_map3.py
@@ -2,6 +2,7 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
@@ -78,6 +79,28 @@ class TestMap3:
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 2, "destinations": [7], "expected_path": None, "expected_cost": 0, "expected_nodes": 7},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map4.py
+++ b/tests/test_map4.py
@@ -2,6 +2,7 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
@@ -80,6 +81,28 @@ class TestMap4:
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [14], "expected_path": [1, 2, 4, 10, 12, 14], "expected_cost": 43, "expected_nodes": 13},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map5.py
+++ b/tests/test_map5.py
@@ -2,11 +2,12 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
 class TestMap5:
-    """Integration tests for Map5 using DFS, BFS, and A*."""
+    """Integration tests for Map5 using DFS, BFS, A*, and GBFS."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -63,6 +64,27 @@ class TestMap5:
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15], "expected_cost": 37, "expected_nodes": 14},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map6.py
+++ b/tests/test_map6.py
@@ -2,6 +2,7 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
@@ -63,6 +64,28 @@ class TestMap6:
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [12], "expected_path": [1, 2, 3, 4, 11, 12], "expected_cost": 36, "expected_nodes": 10},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map7.py
+++ b/tests/test_map7.py
@@ -2,11 +2,12 @@ import pytest
 from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
+from search.algorithms.gbfs import GBFS
 from search.services.parser import load_map
 
 
 class TestMap7:
-    """Integration tests for Map7 using DFS, BFS, and AStar."""
+    """Integration tests for Map7 using DFS, BFS, AStar, and GBFS."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -18,11 +19,11 @@ class TestMap7:
     def test_dfs(self):
         """Test DFS with various origin-destination pairs."""
         test_cases = [
-            {"origin": 1, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 6, "destinations": [12, 18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 1, "destinations": [14], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 7, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 10, "destinations": [1], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [18], "expected_path": [1, 2, 3, 4, 5, 12, 11, 10, 9, 8, 7, 13, 14, 18], "expected_cost": 88, "expected_nodes": 17},
+            {"origin": 6, "destinations": [12, 18], "expected_path": [6, 1, 2, 3, 4, 5, 12], "expected_cost": 50, "expected_nodes": 8},
+            {"origin": 1, "destinations": [14], "expected_path": [1, 2, 3, 4, 5, 12, 11, 10, 9, 8, 7, 13, 14], "expected_cost": 78, "expected_nodes": 16},
+            {"origin": 7, "destinations": [18], "expected_path": [7, 6, 1, 2, 3, 4, 5, 12, 11, 10, 15, 18], "expected_cost": 80, "expected_nodes": 16},
+            {"origin": 10, "destinations": [1], "expected_path": [10, 9, 8, 7, 6, 1], "expected_cost": 14, "expected_nodes": 9},
         ]
 
         dfs = DFS(self.graph)
@@ -44,11 +45,11 @@ class TestMap7:
     def test_bfs(self):
         """Test BFS with various origin-destination pairs."""
         test_cases = [
-            {"origin": 1, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 6, "destinations": [12, 18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 1, "destinations": [14], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 7, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 10, "destinations": [1], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [18], "expected_path": [1, 6, 7, 13, 14, 18], "expected_cost": 28, "expected_nodes": 17},
+            {"origin": 6, "destinations": [12, 18], "expected_path": [6, 7, 13, 12], "expected_cost": 16, "expected_nodes": 12},
+            {"origin": 1, "destinations": [14], "expected_path": [1, 6, 7, 13, 14], "expected_cost": 18, "expected_nodes": 14},
+            {"origin": 7, "destinations": [18], "expected_path": [7, 13, 14, 18], "expected_cost": 23, "expected_nodes": 17},
+            {"origin": 10, "destinations": [1], "expected_path": [10, 9, 8, 7, 6, 1], "expected_cost": 14, "expected_nodes": 17},
         ]
 
         bfs = BFS(self.graph)
@@ -70,16 +71,38 @@ class TestMap7:
     def test_astar(self):
         """Test A* with various origin-destination pairs."""
         test_cases = [
-            {"origin": 1, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 6, "destinations": [12, 18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 1, "destinations": [14], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 7, "destinations": [18], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
-            {"origin": 10, "destinations": [1], "expected_path": [], "expected_cost": 0, "expected_nodes": 0},
+            {"origin": 1, "destinations": [18], "expected_path": [1, 6, 7, 13, 14, 18], "expected_cost": 28, "expected_nodes": 9},
+            {"origin": 6, "destinations": [12, 18], "expected_path": [6, 7, 13, 12], "expected_cost": 16, "expected_nodes": 7},
+            {"origin": 1, "destinations": [14], "expected_path": [1, 6, 7, 13, 14], "expected_cost": 18, "expected_nodes": 8},
+            {"origin": 7, "destinations": [18], "expected_path": [7, 13, 14, 18], "expected_cost": 23, "expected_nodes": 7},
+            {"origin": 10, "destinations": [1], "expected_path": [10, 9, 8, 7, 6, 1], "expected_cost": 14, "expected_nodes": 9},
         ]
 
         astar = AStar(self.graph)
         for tc in test_cases:
             result = astar.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+
+    def test_gbfs(self):
+        """Test GBFS with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [18], "expected_path": [1, 2, 3, 4, 5, 12, 13, 14, 18], "expected_cost": 74, "expected_nodes": 12},
+        ]
+
+        gbfs = GBFS(self.graph)
+        for tc in test_cases:
+            result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]


### PR DESCRIPTION
I implemented test_gbfs method in every map test file (1-7) to iterate through a list of test cases.  Each test case uses the map's default origin and destination points, asserting against verified empirical results for path, cost, and nodes created.

Final Validation: Ran the complete suite for maps 1-7. All 27 tests (covering DFS, BFS, A*, and GBFS) are passing successfully.

Closes #61 