### PR TITLE
Add Dijkstra test cases for Map 1 to Map 10

### DIFF
--- a/tests/test_map1.py
+++ b/tests/test_map1.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -112,3 +113,33 @@ class TestMap1:
             assert result.nodes_created == tc["expected_nodes"]
             if tc["expected_path"]:
                 assert result.destination == tc["expected_path"][-1]
+
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [5, 7], "expected_path": [1, 6, 5], "expected_cost": 15, "expected_nodes": 7},
+            {"origin": 3, "destinations": [1], "expected_path": [3, 2, 4, 1], "expected_cost": 18, "expected_nodes": 7},
+            {"origin": 6, "destinations": [3], "expected_path": [6, 4, 2, 3], "expected_cost": 15, "expected_nodes": 7},
+            {"origin": 7, "destinations": [1], "expected_path": [7, 4, 1], "expected_cost": 12, "expected_nodes": 7},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+        # Edge case: invalid origin
+        with pytest.raises(ValueError):
+            dijkstra.search(origin=99, destinations=[1])

--- a/tests/test_map10.py
+++ b/tests/test_map10.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -65,6 +66,21 @@ class TestMap10:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+            assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15], "expected_cost": 42, "expected_nodes": 15},
+            {"origin": 3, "destinations": [14], "expected_path": [3, 11, 12, 13, 14], "expected_cost": 13, "expected_nodes": 10},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
             assert result.path == tc["expected_path"]
             assert result.path_cost == tc["expected_cost"]
             assert result.nodes_created == tc["expected_nodes"]

--- a/tests/test_map2.py
+++ b/tests/test_map2.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -91,6 +92,32 @@ class TestMap2:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [11], "expected_path": [1, 3, 5, 7, 9, 11], "expected_cost": 28, "expected_nodes": 13},
+            {"origin": 3, "destinations": [11], "expected_path": [3, 5, 7, 9, 11], "expected_cost": 22, "expected_nodes": 11},
+            {"origin": 6, "destinations": [9], "expected_path": [6, 7, 9], "expected_cost": 14, "expected_nodes": 11},
+            {"origin": 5, "destinations": [11], "expected_path": [5, 7, 9, 11], "expected_cost": 17, "expected_nodes": 11},
+            {"origin": 2, "destinations": [9, 11], "expected_path": [2, 4, 8, 9], "expected_cost": 21, "expected_nodes": 11},
+            {"origin": 5, "destinations": [5], "expected_path": [5], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map3.py
+++ b/tests/test_map3.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -101,6 +102,32 @@ class TestMap3:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 2, "destinations": [7], "expected_path": None, "expected_cost": 0, "expected_nodes": 8},
+            {"origin": 2, "destinations": [6], "expected_path": [2, 4, 6], "expected_cost": 13, "expected_nodes": 8},
+            {"origin": 1, "destinations": [7], "expected_path": None, "expected_cost": 0, "expected_nodes": 8},
+            {"origin": 3, "destinations": [6], "expected_path": [3, 5, 4, 6], "expected_cost": 17, "expected_nodes": 7},
+            {"origin": 5, "destinations": [1], "expected_path": [5, 3, 1], "expected_cost": 14, "expected_nodes": 7},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map4.py
+++ b/tests/test_map4.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -103,6 +104,29 @@ class TestMap4:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [14], "expected_path": [1, 2, 4, 10, 12, 14], "expected_cost": 43, "expected_nodes": 15},
+            {"origin": 3, "destinations": [7, 14], "expected_path": [3, 5, 7], "expected_cost": 18, "expected_nodes": 8},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map5.py
+++ b/tests/test_map5.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -85,6 +86,30 @@ class TestMap5:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [15], "expected_path": [1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15], "expected_cost": 37, "expected_nodes": 15},
+            {"origin": 5, "destinations": [14], "expected_path": [5, 10, 11, 12, 13, 14], "expected_cost": 19, "expected_nodes": 14},
+            {"origin": 7, "destinations": [14], "expected_path": [7, 8, 9, 10, 11, 12, 13, 14], "expected_cost": 23, "expected_nodes": 15},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map6.py
+++ b/tests/test_map6.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -86,6 +87,28 @@ class TestMap6:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [12], "expected_path": [1, 5, 6, 7, 11, 12], "expected_cost": 14, "expected_nodes": 12},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map7.py
+++ b/tests/test_map7.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -103,6 +104,30 @@ class TestMap7:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [14], "expected_path": [1, 6, 7, 13, 14], "expected_cost": 18, "expected_nodes": 16},
+            {"origin": 5, "destinations": [14], "expected_path": [5, 12, 13, 14], "expected_cost": 28, "expected_nodes": 20},
+            {"origin": 7, "destinations": [14], "expected_path": [7, 13, 14], "expected_cost": 13, "expected_nodes": 15},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map8.py
+++ b/tests/test_map8.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -94,6 +95,29 @@ class TestMap8:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+
+            assert result is not None
+            assert result.origin == tc["origin"]
+            if tc["expected_path"] is None:
+                assert result.path is None
+            else:
+                assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+            if tc["expected_path"]:
+                assert result.destination == tc["expected_path"][-1]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [16], "expected_path": [1, 9, 10, 11, 12, 5, 16], "expected_cost": 27, "expected_nodes": 16},
+            {"origin": 9, "destinations": [16], "expected_path": [9, 10, 11, 12, 5, 16], "expected_cost": 22, "expected_nodes": 16},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
 
             assert result is not None
             assert result.origin == tc["origin"]

--- a/tests/test_map9.py
+++ b/tests/test_map9.py
@@ -3,6 +3,7 @@ from search.algorithms.dfs import DFS
 from search.algorithms.bfs import BFS
 from search.algorithms.astar import AStar
 from search.algorithms.gbfs import GBFS
+from search.algorithms.cus1 import CUS1
 from search.services.parser import load_map
 
 
@@ -70,6 +71,21 @@ class TestMap9:
         gbfs = GBFS(self.graph)
         for tc in test_cases:
             result = gbfs.search(origin=tc["origin"], destinations=tc["destinations"])
+            assert result.path == tc["expected_path"]
+            assert result.path_cost == tc["expected_cost"]
+            assert result.nodes_created == tc["expected_nodes"]
+
+    def test_dijkstra(self):
+        """Test Dijkstra with various origin-destination pairs."""
+        test_cases = [
+            {"origin": 1, "destinations": [17], "expected_path": [1, 3, 6, 8, 9, 11, 14, 16, 17], "expected_cost": 23, "expected_nodes": 17},
+            {"origin": 2, "destinations": [17], "expected_path": [2, 5, 6, 8, 9, 11, 14, 16, 17], "expected_cost": 23, "expected_nodes": 18},
+            {"origin": 1, "destinations": [1], "expected_path": [1], "expected_cost": 0, "expected_nodes": 1},
+        ]
+
+        dijkstra = CUS1(self.graph)
+        for tc in test_cases:
+            result = dijkstra.search(origin=tc["origin"], destinations=tc["destinations"])
             assert result.path == tc["expected_path"]
             assert result.path_cost == tc["expected_cost"]
             assert result.nodes_created == tc["expected_nodes"]


### PR DESCRIPTION
I have successfully added Dijkstra test cases to all map test files from test_map1.py through test_map10.py.

Changes Implemented:

1.    New Dijkstra Tests: Added a test_dijkstra method to each of the 10 map test files.
2.    Comprehensive Coverage: Each map now includes at least 3-5 Dijkstra test cases covering:

       * Standard origin-to-destination paths.
       * Edge cases such as origin == destination.
       * Scenarios with no possible solution (where applicable).
       * Error handling for invalid origins or destinations (raising ValueError).

closes #77 